### PR TITLE
add order ship lock for selected orders

### DIFF
--- a/Components/Blisstribute/Order/Sync.php
+++ b/Components/Blisstribute/Order/Sync.php
@@ -233,11 +233,6 @@ class Shopware_Components_Blisstribute_Order_Sync extends Shopware_Components_Bl
                     throw new Shopware_Components_Blisstribute_Exception_ValidationMappingException('order aborted');
                 }
 
-                if ($order->getOrderStatus()->getId() == 21 || $order->getPaymentStatus()->getId() == 21) {
-                    $this->logMessage('order inspection necessary', __FUNCTION__, Logger::ERROR);
-                    throw new Shopware_Components_Blisstribute_Exception_ValidationMappingException('order inspection necessary');
-                }
-
                 return true;
                 break;
 
@@ -252,11 +247,6 @@ class Shopware_Components_Blisstribute_Order_Sync extends Shopware_Components_Bl
                     $modelManager->flush();
 
                     throw new Shopware_Components_Blisstribute_Exception_ValidationMappingException('order aborted');
-                }
-
-                if ($order->getOrderStatus()->getId() == 21 || $order->getPaymentStatus()->getId() == 21) {
-                    $this->logMessage('order inspection necessary', __FUNCTION__, Logger::ERROR);
-                    throw new Shopware_Components_Blisstribute_Exception_ValidationMappingException('order inspection necessary');
                 }
 
                 return true;

--- a/Components/Blisstribute/Order/SyncMapping.php
+++ b/Components/Blisstribute/Order/SyncMapping.php
@@ -152,6 +152,7 @@ class Shopware_Components_Blisstribute_Order_SyncMapping extends Shopware_Compon
         $order = $this->getModelEntity()->getOrder();
         $customer = $order->getCustomer();
         $billingAddress = $order->getBilling();
+		$orderShipLock = false;
 
         $orderRemark = array();
         if (trim($order->getCustomerComment()) != '') {
@@ -165,6 +166,10 @@ class Shopware_Components_Blisstribute_Order_SyncMapping extends Shopware_Compon
         if ($order->getPaymentStatus()->getId() == 21) {
             $orderRemark[] = 'Zahlung prüfen - Shopware Zahlungshinweis';
         }
+		
+		if (!empty($orderRemark)) {
+			$orderShipLock = true;
+		}
 
         // todo change to config decision
 //        $customerNumber = $customer->getBilling()->getNumber();
@@ -192,7 +197,7 @@ class Shopware_Components_Blisstribute_Order_SyncMapping extends Shopware_Compon
             'customerOrderNumber' => '',
             'isAnonymousCustomer' => false,
             'orderDate' => $order->getOrderTime()->format('Y-m-d H:i:s'),
-            'orderShipLock' => false,
+            'orderShipLock' => $orderShipLock,
             'orderCurrency' => $order->getCurrency(),
             'orderRemark' => implode(' - ', $orderRemark),
             'isB2BOrder' => $isB2BOrder,


### PR DESCRIPTION
actual:
orders with a status to check the order manuel or a customer comment, for example the payment was not successful, stayed in the webshop. after a manuel check, the orders were submitted to bliss.

now:
a order with a status to check the order manuel or customer comment were submitted with a ship lock to bliss.