### PR TITLE
fix order sync after order registration

### DIFF
--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -1568,15 +1568,18 @@ class Shopware_Plugins_Backend_ExitBBlisstribute_Bootstrap extends Shopware_Comp
         /** @var \Shopware\CustomModels\Blisstribute\BlisstributeOrderRepository $blisstributeOrderRepository */
         $blisstributeOrderRepository = $modelManager->getRepository('Shopware\CustomModels\Blisstribute\BlisstributeOrder');
         $blisstributeOrder = $blisstributeOrderRepository->findByOrder($order);
-        if ($blisstributeOrder === null) {	
+        if ($blisstributeOrder === null) {
+		$status = \Shopware\CustomModels\Blisstribute\BlisstributeOrder::EXPORT_STATUS_CREATION_PENDING;
+			
+		if (!$this->get('config')->get('blisstribute-auto-sync-order')) {
+			$status = \Shopware\CustomModels\Blisstribute\BlisstributeOrder::EXPORT_STATUS_NONE;
+		}
+		
             $blisstributeOrder = new \Shopware\CustomModels\Blisstribute\BlisstributeOrder();
             $blisstributeOrder->setLastCronAt(new DateTime())
                 ->setOrder($order)
+		->setStatus($status)
                 ->setTries(0);
-		
-	  	if ($this->get('config')->get('blisstribute-auto-sync-order')) {
-                	$blisstributeOrder->setStatus(\Shopware\CustomModels\Blisstribute\BlisstributeOrder::EXPORT_STATUS_CREATION_PENDING);
-            	}
 
             $modelManager->persist($blisstributeOrder);
             $modelManager->flush();

--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -1568,18 +1568,15 @@ class Shopware_Plugins_Backend_ExitBBlisstribute_Bootstrap extends Shopware_Comp
         /** @var \Shopware\CustomModels\Blisstribute\BlisstributeOrderRepository $blisstributeOrderRepository */
         $blisstributeOrderRepository = $modelManager->getRepository('Shopware\CustomModels\Blisstribute\BlisstributeOrder');
         $blisstributeOrder = $blisstributeOrderRepository->findByOrder($order);
-        if ($blisstributeOrder === null) {
-			$status = \Shopware\CustomModels\Blisstribute\BlisstributeOrder::EXPORT_STATUS_CREATION_PENDING;
-			
-			if (!$this->get('config')->get('blisstribute-auto-sync-order')) {
-            	$status = \Shopware\CustomModels\Blisstribute\BlisstributeOrder::EXPORT_STATUS_NONE;            
-        	}
-			
+        if ($blisstributeOrder === null) {	
             $blisstributeOrder = new \Shopware\CustomModels\Blisstribute\BlisstributeOrder();
             $blisstributeOrder->setLastCronAt(new DateTime())
                 ->setOrder($order)
-                ->setStatus($status)
                 ->setTries(0);
+		
+	  	if ($this->get('config')->get('blisstribute-auto-sync-order')) {
+                	$blisstributeOrder->setStatus(\Shopware\CustomModels\Blisstribute\BlisstributeOrder::EXPORT_STATUS_CREATION_PENDING);
+            	}
 
             $modelManager->persist($blisstributeOrder);
             $modelManager->flush();

--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -1569,10 +1569,16 @@ class Shopware_Plugins_Backend_ExitBBlisstribute_Bootstrap extends Shopware_Comp
         $blisstributeOrderRepository = $modelManager->getRepository('Shopware\CustomModels\Blisstribute\BlisstributeOrder');
         $blisstributeOrder = $blisstributeOrderRepository->findByOrder($order);
         if ($blisstributeOrder === null) {
+			$status = \Shopware\CustomModels\Blisstribute\BlisstributeOrder::EXPORT_STATUS_CREATION_PENDING;
+			
+			if (!$this->get('config')->get('blisstribute-auto-sync-order')) {
+            	$status = \Shopware\CustomModels\Blisstribute\BlisstributeOrder::EXPORT_STATUS_NONE;            
+        	}
+			
             $blisstributeOrder = new \Shopware\CustomModels\Blisstribute\BlisstributeOrder();
             $blisstributeOrder->setLastCronAt(new DateTime())
                 ->setOrder($order)
-                ->setStatus(\Shopware\CustomModels\Blisstribute\BlisstributeOrder::EXPORT_STATUS_CREATION_PENDING)
+                ->setStatus($status)
                 ->setTries(0);
 
             $modelManager->persist($blisstributeOrder);


### PR DESCRIPTION
actual:
after the order registration, the order get the status pending.
if the direct order export to bliss is deactivated, the cron doesn't export the order because of this status.

now:
if the direct order export to bliss is deactivated, the order get the status "open" and the cron can export the order to bliss now.