### PR TITLE
fix article trigger sync

### DIFF
--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -759,6 +759,11 @@ class Shopware_Plugins_Backend_ExitBBlisstribute_Bootstrap extends Shopware_Comp
         $config = $container->get('shopware.plugin.cached_config_reader')->getByPluginName('ExitBBlisstribute', $shop);
         $pluginConfig = new Enlight_Config($config);
 
+        $this->logDebug('onRunBlisstributeArticleSyncCron::repair trigger sync flag started');
+        $sql = "UPDATE s_plugin_blisstribute_articles a INNER JOIN s_articles b ON a.s_article_id = b.id SET trigger_sync = 1 WHERE a.modified_at < b.changetime AND trigger_sync = 0";
+        $this->get('db')->query($sql);
+        $this->logDebug('onRunBlisstributeArticleSyncCron::repair trigger sync flag done');
+
         // If the user disabled article synchronization, stop here.
         if (!$pluginConfig->get('blisstribute-article-sync-enabled')) {
             $this->_log(date('r') . ' - BLISSTRIBUTE article sync is disabled' . PHP_EOL);

--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -760,7 +760,7 @@ class Shopware_Plugins_Backend_ExitBBlisstribute_Bootstrap extends Shopware_Comp
         $pluginConfig = new Enlight_Config($config);
 
         $this->logDebug('onRunBlisstributeArticleSyncCron::repair trigger sync flag started');
-        $sql = "UPDATE s_plugin_blisstribute_articles a INNER JOIN s_articles b ON a.s_article_id = b.id SET trigger_sync = 1 WHERE a.modified_at < b.changetime AND trigger_sync = 0";
+        $sql = "UPDATE s_plugin_blisstribute_articles a INNER JOIN s_articles b ON a.s_article_id = b.id SET a.trigger_sync = 1 WHERE a.last_cron_at < b.changetime AND trigger_sync = 0";
         $this->get('db')->query($sql);
         $this->logDebug('onRunBlisstributeArticleSyncCron::repair trigger sync flag done');
 


### PR DESCRIPTION
In some cases, the following model events will not be triggered, if an article update was performed:
'Shopware\Models\Article\Article::postPersist'
'Shopware\Models\Article\Article::postUpdate'
'Shopware\Models\Article\Detail::postPersist'
'Shopware\Models\Article\Detail::postUpdate'

If articles will be synced by an third party system and over the Shopware API, these events will not be triggered.

This PR fix the issue und set the trigger flag for articles, which article updatetime is higher than the modified_at value on the s_plugin_blisstribute_articles table.
