### PR TITLE
add event on order sync mapping

### DIFF
--- a/Components/Blisstribute/Order/SyncMapping.php
+++ b/Components/Blisstribute/Order/SyncMapping.php
@@ -173,10 +173,15 @@ class Shopware_Components_Blisstribute_Order_SyncMapping extends Shopware_Compon
 
         $this->logDebug('orderSyncMapping::buildBaseData::done');
         $this->logDebug('orderSyncMapping::buildBaseData::result:' . json_encode($this->orderData));
-
-
-
-        return $this->orderData;
+        
+        // Allow plugins to change the data
+        return Enlight()->Events()->filter(
+            'ExitBBlisstribute_OrderSyncMapping_AfterBuildBaseData',
+            $this->orderData,
+            array(
+                'subject' => $this
+            )
+        );
     }
 
     /**


### PR DESCRIPTION
This PR add a new event ExitBBlisstribute_OrderSyncMapping_AfterBuildBaseData to allow plugins to change order data before the order is submitted to Blisstribute.