### PR TITLE
add event to add article prices over plugins

### DIFF
--- a/Components/Blisstribute/Article/SyncMapping.php
+++ b/Components/Blisstribute/Article/SyncMapping.php
@@ -366,7 +366,9 @@ class Shopware_Components_Blisstribute_Article_SyncMapping extends Shopware_Comp
             }
         }
 
-        return $prices;
+        // Allow plugins to add prices
+        return Enlight()->Events()->filter('ExitBBlisstribute_ArticleSyncMapping_AfterGetPrices', $prices,
+            ['subject' => $this, 'articleDetail' => $articleDetail]);
     }
 
     /**


### PR DESCRIPTION
This PR add the event ExitBBlisstribute_ArticleSyncMapping_AfterGetPrices to add article prices after plugin price detection.