### PR TITLE
fix custom products

### DIFF
--- a/Components/Blisstribute/Order/SyncMapping.php
+++ b/Components/Blisstribute/Order/SyncMapping.php
@@ -862,16 +862,27 @@ class Shopware_Components_Blisstribute_Order_SyncMapping extends Shopware_Compon
                     $articleData['price'] += round($price, 6);
                 }
 
-
                 if ($configurationArticle->getAttribute()->getSwagCustomProductsMode() == 2) {
                     foreach ($templateCollection as $currentTemplate) {
                         if ($currentTemplate['id'] != $configurationArticle->getArticleId()) {
                             continue;
                         }
 
-                        $value = trim($currentConfigurationData[$currentTemplate['id']][0]);
-                        if ($value != '') {
-                            $orderLineConfiguration[] = ['key' => $currentTemplate['name'], 'value' => $value];
+                        $values = array_map('trim', $currentConfigurationData[$currentTemplate['id']]);
+
+                        foreach ($values as $value) {
+                            if (!empty($currentTemplate['values'])) {
+                                $key = array_search($value, array_column($currentTemplate['values'], 'id'));
+
+                                if ($key !== false) {
+                                    $valueData = $currentTemplate['values'][$key];
+                                    $value = trim($valueData['name']);
+                                }
+                            }
+
+                            if (!empty($value)) {
+                                $orderLineConfiguration[] = ['key' => $currentTemplate['name'], 'value' => $value];
+                            }
                         }
                     }
                 }

--- a/Components/Blisstribute/Order/SyncMapping.php
+++ b/Components/Blisstribute/Order/SyncMapping.php
@@ -860,6 +860,8 @@ class Shopware_Components_Blisstribute_Order_SyncMapping extends Shopware_Compon
 
                 } else {
                     $articleData['price'] += round($price, 6);
+                    $articleData['legacy']['originalPrice'] = $articleData['price'];
+                    $articleData['legacy']['originalPriceAmount'] = round($articleData['price'] * $articleData['quantity'], 2);
                 }
 
                 if ($configurationArticle->getAttribute()->getSwagCustomProductsMode() == 2) {


### PR DESCRIPTION
This PR fixed the following issues:

A)
If a custom product has select fields, the id of the option value will be transferred to bliss, but not the value / name of the selected option.
If a field has option values, the option name will be transferred to bliss. If not, the value of the input field will be transferred.

B)
If a field has the type multiselect, only one entry will be submitted to bliss, but not all selected values.

C) If a custom products has options with up/down prices, the originalPriceAmount was not updated for the voucher calculation. 